### PR TITLE
Support per-case methods and expand YAML automation

### DIFF
--- a/base/apiutil_business.py
+++ b/base/apiutil_business.py
@@ -79,8 +79,7 @@ class RequestBase(object):
             allure.attach(url, f'接口地址：{url}')
             api_name = case_info["baseInfo"]["api_name"]
             allure.attach(api_name, f'接口名：{api_name}')
-            method = case_info["baseInfo"]["method"]
-            allure.attach(method, f'请求方法：{method}')
+            base_method = case_info["baseInfo"].get("method")
             header = self.replace_load(case_info["baseInfo"]["header"])
             allure.attach(str(header), '请求头信息', allure.attachment_type.TEXT)
             try:
@@ -91,12 +90,17 @@ class RequestBase(object):
             for tc in case_info["testCase"]:
                 case_name = tc.pop("case_name")
                 allure.attach(case_name, f'测试用例名称：{case_name}', allure.attachment_type.TEXT)
+                case_method = tc.pop('method', base_method)
+                allure.attach(str(case_method), f'请求方法：{case_method}')
                 # 断言结果解析替换
-                val = self.replace_load(tc.get('validation'))
-                tc['validation'] = val
-                # 字符串形式的列表转换为list类型
-                validation = eval(tc.pop('validation'))
-                allure_validation = str([str(list(i.values())) for i in validation])
+                validation_raw = tc.pop('validation', None)
+                if validation_raw is not None:
+                    val = self.replace_load(validation_raw)
+                    validation = eval(val) if isinstance(val, str) else val
+                    allure_validation = str([str(list(i.values())) for i in validation]) if validation else '[]'
+                else:
+                    validation = []
+                    allure_validation = '[]'
                 allure.attach(allure_validation, "预期结果", allure.attachment_type.TEXT)
                 extract = tc.pop('extract', None)
                 extract_lst = tc.pop('extract_list', None)
@@ -113,7 +117,7 @@ class RequestBase(object):
                                         case_name=case_name,
                                         header=header,
                                         cookies=cookie,
-                                        method=method,
+                                        method=case_method,
                                         file=files, **tc)
                 res_text = res.text
                 allure.attach(res_text, '接口响应信息', allure.attachment_type.TEXT)

--- a/testcase/ProductManager/commitOrder.yaml
+++ b/testcase/ProductManager/commitOrder.yaml
@@ -1,7 +1,7 @@
 - baseInfo:
     api_name: 提交订单
     url: /coupApply/cms/placeAnOrder
-    method: post
+    method: POST
     header:
       Content-Type: application/json;charset=UTF-8
   testCase:
@@ -17,7 +17,13 @@
         consignee_info: {"name": "张三","phone": 13800000000,"address": "北京市海淀区西三环北路74号院4栋3单元1008"}
       validation:
         - eq: { 'message': '提交订单成功' }
-        - eq: {'error_code':'0000'}
+        - eq: { 'error_code': '0000' }
       extract:
         orderNumber: $.orderNumber
         userId: $.userId
+    - case_name: 使用GET方式提交订单
+      method: GET
+      params:
+        goods_id: ${get_extract_data(goodsId,0)}
+      validation:
+        - contains: { 'status_code': 405 }

--- a/testcase/ProductManager/getProductList.yaml
+++ b/testcase/ProductManager/getProductList.yaml
@@ -1,7 +1,7 @@
 - baseInfo:
     api_name: 商品列表
     url: /coupApply/cms/goodsList
-    method: Get
+    method: GET
     header:
       Content-Type: application/x-www-form-urlencoded;charset=UTF-8
       token: ${get_extract_data(cookie)}
@@ -14,5 +14,12 @@
       validation:
         - contains: { 'error_code': '0000' }
       extract_list:
-#        token: '"token": "(.*?)"'
         goodsId: $.goodsList[*].goodsId
+    - case_name: 使用POST方式获取商品列表
+      method: POST
+      data:
+        msgType: getHandsetListOfCust
+        page: 1
+        size: 20
+      validation:
+        - contains: { 'status_code': 405 }

--- a/testcase/ProductManager/orderPay.yaml
+++ b/testcase/ProductManager/orderPay.yaml
@@ -1,7 +1,7 @@
 - baseInfo:
     api_name: 订单支付
     url: /coupApply/cms/orderPay
-    method: post
+    method: POST
     header:
       Content-Type: application/json;charset=UTF-8
   testCase:
@@ -13,3 +13,10 @@
       validation:
         - contains: { 'message': '订单支付成功' }
         - contains: { 'error_code': '0000' }
+    - case_name: 使用GET方式支付订单
+      method: GET
+      params:
+        orderNumber: ${get_extract_data(orderNumber)}
+        userId: ${get_extract_data(userId)}
+      validation:
+        - contains: { 'status_code': 405 }

--- a/testcase/ProductManager/productDetail.yaml
+++ b/testcase/ProductManager/productDetail.yaml
@@ -1,7 +1,7 @@
 - baseInfo:
     api_name: 商品详情
     url: /coupApply/cms/productDetail
-    method: post
+    method: POST
     header:
       Content-Type: application/json;charset=UTF-8
   testCase:
@@ -12,3 +12,11 @@
         size: 20
       validation:
         - contains: { 'error_code': '4000' }
+    - case_name: 使用GET方式获取商品详情
+      method: GET
+      params:
+        pro_id: ${get_extract_data(goodsId)}
+        page: 1
+        size: 20
+      validation:
+        - contains: { 'status_code': 405 }

--- a/testcase/Single interface/addUser.yaml
+++ b/testcase/Single interface/addUser.yaml
@@ -16,34 +16,30 @@
       validation:
         - contains: { 'status_code': 200 }
         - contains: { 'msg': '新增成功' }
-    - case_name: 无效新增·缺少token
+    - case_name: 无效新增·缺少必填参数{field}
       data:
         username: testadduser
         password: tset6789890
         role_id: 123456789
         dates: '2023-12-31'
         phone: 13800000000
-        token:
+        token: ${get_extract_data(token)}
+      missing_fields:
+        - field: token
+          mode: empty
+        - field: username
+        - field: role_id
       validation:
         - contains: { 'status_code': 200 }
         - contains: { 'msg': '新增失败' }
-    - case_name: 无效新增·缺少必填参数username
-      data:
+    - case_name: 使用GET方式新增用户
+      method: GET
+      params:
+        username: testadduser
         password: tset6789890
         role_id: 123456789
         dates: '2023-12-31'
         phone: 13800000000
-        token:
+        token: ${get_extract_data(token)}
       validation:
-        - contains: { 'status_code': 200 }
-        - contains: { 'msg': '新增失败' }
-    - case_name: 无效新增·缺少必填参数role_id
-      data:
-        username: testadduser
-        password: tset6789890
-        dates: '2023-12-31'
-        phone: 13800000000
-        token:
-      validation:
-        - contains: { 'status_code': 200 }
-        - contains: { 'msg': '新增失败' }
+        - contains: { 'status_code': 405 }

--- a/testcase/Single interface/deleteUser.yaml
+++ b/testcase/Single interface/deleteUser.yaml
@@ -15,11 +15,21 @@
         user_id: 1238393873922
       validation:
         - contains: { 'msg': '删除失败' }
-    - case_name: 无效删除用户·userid为空
+    - case_name: 无效删除用户·缺少必填参数{field}
       data:
         user_id: 1238393873922
+      missing_fields:
+        - field: user_id
+          mode: empty
+          label: user_id为空
+        - field: user_id
+          mode: remove
+          label: 缺少user_id参数
       validation:
         - contains: { 'msg': '删除失败' }
-    - case_name: 无效删除用户·缺少必填参数
+    - case_name: 使用GET方式删除用户
+      method: GET
+      params:
+        user_id: 123839387391912
       validation:
-        - contains: { 'msg': '删除失败' }
+        - contains: { 'status_code': 405 }

--- a/testcase/Single interface/queryUser.yaml
+++ b/testcase/Single interface/queryUser.yaml
@@ -11,3 +11,9 @@
       validation:
         - contains: { 'msg': '查询成功' }
         - eq: { 'msg_code': 200 }
+    - case_name: 使用GET方式查询用户
+      method: GET
+      params:
+        user_id: 123839387391912
+      validation:
+        - contains: { 'status_code': 200 }

--- a/testcase/Single interface/updateUser.yaml
+++ b/testcase/Single interface/updateUser.yaml
@@ -15,3 +15,13 @@
       validation:
         - contains: { 'status_code': 200 }
         - contains: { 'msg': '更新成功' }
+    - case_name: 使用GET方式修改用户信息
+      method: GET
+      params:
+        username: testadduser
+        password: tset6789#$123
+        role_id: 89588181111112343
+        dates: '2023-12-31'
+        phone: 13800000000
+      validation:
+        - contains: { 'status_code': 405 }


### PR DESCRIPTION
## Summary
- allow individual test cases to override the HTTP method and safely handle optional validations in the single-step and business request executors
- enhance the YAML loader to expand `missing_fields` configurations into parameterized negative cases while keeping multi-step scenarios compatible
- refresh the existing interface YAMLs to consolidate required-field checks and add alternate-method examples for each endpoint