### PR TITLE
Add configurable email notifications for test reports

### DIFF
--- a/common/sendmail.py
+++ b/common/sendmail.py
@@ -1,11 +1,12 @@
+import os
 import smtplib
-from email.mime.text import MIMEText
-from conf.operationConfig import OperationConfig
-from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication  # 附件
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
 from conf import setting
+from conf.operationConfig import OperationConfig
 from common.recordlog import logs
-import re
 
 conf = OperationConfig()
 
@@ -16,11 +17,21 @@ class SendEmail(object):
     def __init__(
             self,
             host=conf.get_section_for_data('EMAIL', 'host'),
+            port=conf.get_section_for_data('EMAIL', 'port'),
             user=conf.get_section_for_data('EMAIL', 'user'),
-            passwd=conf.get_section_for_data('EMAIL', 'passwd')):
+            passwd=conf.get_section_for_data('EMAIL', 'passwd'),
+            security=conf.get_section_for_data('EMAIL', 'security')
+    ):
         self.__host = host
         self.__user = user
         self.__passwd = passwd
+        try:
+            self.__port = int(port) if port else 0
+        except (TypeError, ValueError):
+            self.__port = 0
+        self.__security = (security or 'ssl').strip().lower()
+        if self.__security not in {'ssl', 'starttls', 'none'}:
+            self.__security = 'ssl'
 
     def build_content(self, subject, email_content, addressee=None, atta_file=None):
         """
@@ -30,32 +41,55 @@ class SendEmail(object):
         @param email_content: 邮件正文内容
         @return:
         """
-        user = 'liaison officer' + '<' + self.__user + '>'
+        user = self.__user
         # 收件人
         if addressee is None:
-            addressee = conf.get_section_for_data('EMAIL', 'addressee').split(';')
+            addressee = conf.get_section_for_data('EMAIL', 'addressee')
+        if isinstance(addressee, (list, tuple, set)):
+            recipients = [str(item).strip() for item in addressee if str(item).strip()]
         else:
-            addressee = addressee.split(';')
+            recipients = [segment.strip() for segment in str(addressee).split(';') if segment.strip()]
+        if not recipients:
+            logs.error('收件人列表为空，取消发送邮件')
+            return
         message = MIMEMultipart()
         message['Subject'] = subject
         message['From'] = user
-        message['To'] = ';'.join([re.search(r'(.*)(@)', emi).group(1) + "<" + emi + ">" for emi in addressee])
+        message['To'] = ';'.join(recipients)
 
         # 邮件正文
         text = MIMEText(email_content, _subtype='plain', _charset='utf-8')
         message.attach(text)
 
-        if atta_file is not None:
-            # 附件
-            atta = MIMEApplication(open(atta_file, 'rb').read())
-            atta['Content-Type'] = 'application/octet-stream'
-            atta['Content-Disposition'] = 'attachment; filename="testresult.xls"'
+        attachment_paths = []
+        if atta_file:
+            if isinstance(atta_file, (list, tuple, set)):
+                attachment_paths = [str(path) for path in atta_file if str(path).strip()]
+            else:
+                attachment_paths = [str(atta_file)]
+
+        for file_path in attachment_paths:
+            if not os.path.isfile(file_path):
+                logs.warning('附件文件不存在: %s', file_path)
+                continue
+            with open(file_path, 'rb') as file:
+                atta = MIMEApplication(file.read())
+            atta.add_header('Content-Disposition', 'attachment', filename=os.path.basename(file_path))
             message.attach(atta)
 
+        connection = None
+
         try:
-            service = smtplib.SMTP_SSL(self.__host)
-            service.login(self.__user, self.__passwd)
-            service.sendmail(user, addressee, message.as_string())
+            if self.__security == 'ssl':
+                port = self.__port or 465
+                connection = smtplib.SMTP_SSL(self.__host, port)
+            else:
+                port = self.__port or 25
+                connection = smtplib.SMTP(self.__host, port)
+                if self.__security == 'starttls':
+                    connection.starttls()
+            connection.login(self.__user, self.__passwd)
+            connection.sendmail(user, recipients, message.as_string())
         except smtplib.SMTPConnectError as e:
             logs.error('邮箱服务器连接失败！', e)
         except smtplib.SMTPAuthenticationError as e:
@@ -68,7 +102,12 @@ class SendEmail(object):
             logs.error(e)
         else:
             logs.info('邮件发送成功!')
-            service.quit()
+        finally:
+            if connection is not None:
+                try:
+                    connection.quit()
+                except Exception:
+                    pass
 
 
 class BuildEmail(SendEmail):
@@ -93,13 +132,18 @@ class BuildEmail(SendEmail):
         notrun_num = len(not_running)
         total = success_num + fail_num + error_num + notrun_num
         execute_case = success_num + fail_num
-        pass_result = "%.2f%%" % (success_num / execute_case * 100)
-        fail_result = "%.2f%%" % (fail_num / execute_case * 100)
-        err_result = "%.2f%%" % (error_num / execute_case * 100)
+        if execute_case:
+            pass_result = "%.2f%%" % (success_num / execute_case * 100)
+            fail_result = "%.2f%%" % (fail_num / execute_case * 100)
+            err_result = "%.2f%%" % (error_num / execute_case * 100)
+        else:
+            pass_result = fail_result = err_result = "0.00%"
         # 设置邮件主题、收件人、内容
         subject = conf.get_section_for_data('EMAIL', 'subject')
-        addressee = conf.get_section_for_data('EMAIL', 'addressee').split(';')
-        content = "     ***项目接口测试，共测试接口%s个，通过%s个，失败%s个，错误%s个，未执行%s个，通过率%s，失败率%s，错误率%s。" \
-                  "详细测试结果请参见附件。" % (
-                      total, success_num, fail_num, error_num, notrun_num, pass_result, fail_result, err_result)
-        self.build_content(addressee, subject, content, atta_file)
+        addressee = conf.get_section_for_data('EMAIL', 'addressee')
+        content = (
+            "***项目接口测试，共测试接口%s个，通过%s个，失败%s个，错误%s个，未执行%s个，"
+            "通过率%s，失败率%s，错误率%s。详细测试结果请参见附件。"
+            % (total, success_num, fail_num, error_num, notrun_num, pass_result, fail_result, err_result)
+        )
+        self.build_content(subject, content, addressee, atta_file)

--- a/conf/config.ini
+++ b/conf/config.ini
@@ -32,10 +32,12 @@ database = admin
 
 [EMAIL]
 host = smtp.163.com
-port = 25
+port = 465
+security = ssl
+enable = false
 user = 发件人邮箱地址
 passwd = *****这里填邮箱的授权码，不是邮箱登录密码*****
-addressee = 收件邮箱地址，多个收件人以;隔开，但是这里不用这个邮件发送，使用的是jenkins自带的邮件发送功能
+addressee = 收件邮箱地址，多个收件人以;隔开
 subject = 接口测试
 
 [SSH]

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,23 @@
 # -*- coding: utf-8 -*-
+import datetime
+import os
+import shutil
 import time
+import warnings
+from pathlib import Path
+from typing import Optional
 
 import pytest
 
-from common.parser_yaml import ReadYamlData
 from base.removefile import remove_file
-
-import warnings
+from common.parser_yaml import ReadYamlData
+from common.recordlog import logs
+from common.sendmail import SendEmail
+from conf import setting
+from conf.operationConfig import OperationConfig
 
 yfd = ReadYamlData()
+config_reader = OperationConfig()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -25,39 +34,116 @@ def pytest_sessionstart(session):
     session.config._custom_session_start_time = time.time()
 
 
+def _parse_bool(value):
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 0:
+        seconds = 0
+    duration = datetime.timedelta(seconds=round(seconds))
+    return str(duration)
+
+
+def _get_session_start_time(terminalreporter):
+    return (
+        getattr(terminalreporter, "_sessionstarttime", None)
+        or getattr(terminalreporter, "_session_start_time", None)
+        or getattr(terminalreporter.config, "_custom_session_start_time", None)
+    )
+
+
+def _collect_report_nodeids(reports):
+    node_ids = []
+    for report in reports:
+        node_id = getattr(report, "nodeid", "")
+        if node_id:
+            node_ids.append(node_id)
+    return node_ids
+
+
 def generate_test_summary(terminalreporter):
     """生成测试结果摘要字符串"""
     total = terminalreporter._numcollected
-    passed = len(terminalreporter.stats.get('passed', []))
-    failed = len(terminalreporter.stats.get('failed', []))
-    error = len(terminalreporter.stats.get('error', []))
-    skipped = len(terminalreporter.stats.get('skipped', []))
-    # pytest 8 不支持terminalreporter._sessionstarttime
-    # duration = time.time() - terminalreporter._sessionstarttime
+    passed_reports = terminalreporter.stats.get('passed', [])
+    failed_reports = terminalreporter.stats.get('failed', [])
+    error_reports = terminalreporter.stats.get('error', [])
+    skipped_reports = terminalreporter.stats.get('skipped', [])
 
-    start_time = (
-            getattr(terminalreporter, "_sessionstarttime", None)
-            or getattr(terminalreporter, "_session_start_time", None)
-            or getattr(terminalreporter.config, "_custom_session_start_time", None)
-    )
-    if start_time:
-        duration = time.time() - start_time
-    else:
-        duration = 0.0
+    start_time = _get_session_start_time(terminalreporter)
+    duration_seconds = time.time() - start_time if start_time else 0.0
+    duration = _format_duration(duration_seconds)
 
-    summary = f"""
-    自动化测试结果 (请着重关注测试失败的接口)：
-    测试用例总数：{total}
-    测试通过数：{passed}
-    测试失败数：{failed}
-    错误数量：{error}
-    跳过执行数量：{skipped}
-    执行总时长：{duration}
-    """
+    summary_lines = [
+        "自动化测试结果 (请着重关注测试失败的接口)：",
+        f"测试用例总数：{total}",
+        f"测试通过数：{len(passed_reports)}",
+        f"测试失败数：{len(failed_reports)}",
+        f"错误数量：{len(error_reports)}",
+        f"跳过执行数量：{len(skipped_reports)}",
+        f"执行总时长：{duration}",
+    ]
+    summary = "\n".join(summary_lines)
     print(summary)
-    return summary
+
+    details = [summary, ""]
+    for title, reports in (
+        ("失败用例", failed_reports),
+        ("错误用例", error_reports),
+        ("跳过用例", skipped_reports),
+    ):
+        nodes = _collect_report_nodeids(reports)
+        if nodes:
+            details.append(f"{title}:")
+            details.extend([f"- {node}" for node in nodes])
+            details.append("")
+
+    detail_text = "\n".join(line for line in details if line is not None)
+    return detail_text.strip()
+
+
+def _should_send_email() -> bool:
+    return _parse_bool(config_reader.get_section_for_data('EMAIL', 'enable'))
+
+
+def _build_report_attachment() -> Optional[str]:
+    if setting.REPORT_TYPE == 'allure':
+        allure_dir = Path(setting.FILE_PATH['TEMP'])
+        if not allure_dir.exists() or not any(allure_dir.iterdir()):
+            return None
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive_base = allure_dir.parent / f"{allure_dir.name}_{timestamp}"
+        archive_path = shutil.make_archive(str(archive_base), 'zip', allure_dir)
+        return archive_path
+    if setting.REPORT_TYPE == 'tm':
+        report_file = Path(setting.FILE_PATH['TMR']) / 'testReport.html'
+        if report_file.exists():
+            return str(report_file)
+    return None
+
+
+def _send_summary_email(summary: str):
+    if not _should_send_email():
+        return
+
+    attachment = _build_report_attachment()
+    attachments = [attachment] if attachment else None
+    subject = config_reader.get_section_for_data('EMAIL', 'subject') or '接口自动化测试报告'
+
+    try:
+        sender = SendEmail()
+        sender.build_content(subject, summary, atta_file=attachments)
+    except Exception as exc:  # pragma: no cover - 不影响测试用例执行
+        logs.error('发送测试报告邮件失败: %s', exc, exc_info=True)
+    finally:
+        if attachment and attachment.endswith('.zip') and os.path.exists(attachment):
+            try:
+                os.remove(attachment)
+            except OSError:
+                logs.warning('临时报告压缩包删除失败: %s', attachment)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """自动收集pytest框架执行的测试结果并打印摘要信息"""
     summary = generate_test_summary(terminalreporter)
+    _send_summary_email(summary)


### PR DESCRIPTION
## Summary
- enhance the pytest terminal summary helper to build a detailed message and reuse it when an email notification is required
- enable configurable email delivery including connection security, attachments of the generated report, and robust recipient handling
- document the email toggle and connection settings in `conf/config.ini`

## Testing
- `pytest -q` *(fails: target API host 127.0.0.1:8787 is not reachable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bbcd69e08330b45756728894abdf